### PR TITLE
Outdated Mqtt Broker address in echo example

### DIFF
--- a/contributions/add/MQTTClient-C/samples/mdk/MQTTEcho.c
+++ b/contributions/add/MQTTClient-C/samples/mdk/MQTTEcho.c
@@ -7,7 +7,7 @@
 #include "certificates.h"
 #endif
 
-#define SERVER_NAME "iot.eclipse.org"
+#define SERVER_NAME "mqtt.eclipseprojects.io"
 #if (MQTT_MBEDTLS != 0)
 #define SERVER_PORT 8883
 #else

--- a/contributions/add/doc/Paho_MQTT_MDK.md
+++ b/contributions/add/doc/Paho_MQTT_MDK.md
@@ -133,7 +133,7 @@ The MQTT Echo sample code is prepared to output `printf` statements for debuggin
 
 ### Run/debug the application
 MQTT Echo is a simple application which:
- - connects to iot.eclipse.org test server
+ - connects to mqtt.eclipseprojects.io test server
  - subscribes to a topic "MDK/sample/#"
  - publishes messages to previously subscribed topic
  - displays messages received back (echo)


### PR DESCRIPTION
Mqtt Broker address in the Mqtt Echo Example was outdated, updated to eclipse's current domain.